### PR TITLE
Dockerize eigengen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY . .
+RUN pip install eigengen
+
+ENTRYPOINT ["eigengen"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# This for those who do not want to wrestle with python versions
+
+docker build . -t eigengen

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This for those who do not want to wrestle with python versions
+
+# You can run this file directly or add the below command as function to your 
+# shell login config of choice. E.g. ~/.zprofile:
+# function eigengen {
+#   docker run \
+#     --env OPENAI_API_KEY \
+#     --rm -i \
+#     --volume "$( pwd ):/usr/src/app" \
+#     eigengen "$@" 
+# }
+
+docker run \
+--env OPENAI_API_KEY \
+--rm -i \
+--volume "$( pwd ):/usr/src/app" \
+eigengen "$@" 


### PR DESCRIPTION
This PR adds dockerfile, build.sh, and run.sh to allow for using eigengen without installing and managing python version