### PR TITLE
Fix: o1 models failed to produce output

### DIFF
--- a/src/eigengen/providers.py
+++ b/src/eigengen/providers.py
@@ -165,6 +165,8 @@ class OpenAIProvider(Provider):
                                 print(part, end="")
                 else:
                     content = response.choices[0].message.content
+                    if mode not in ["diff"]:
+                        print(content)
 
                 return content
             except OpenAIRateLimitError as e:


### PR DESCRIPTION
When using o1 models in default mode there is no output produced. This is fixed by printing from the else branch too.